### PR TITLE
Ensure current rebar builds a working joxa escript

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,4 +17,6 @@
 {escript_incl_apps,
  [erlware_commons, getopt]}.
 
+{escript_emu_args, "%%!\n"}.
+
 {post_hooks, [{compile, "make jxa"}]}.


### PR DESCRIPTION
When building the joxa shell with the most current version of rebar
(i.e., 1b52a597), the resulting escript does not work anymore.

This is because the Erlang emulator doesn't read from stdin anymore due
to the now default `escript_emu_args` options
"%%! -pa joxa/joxa/ebin -noshell -noinput" being passed to it by the
escript.

Explicitly setting the `escript_emu_args` in rebar.config to "%%!\n",
which is the default in the most recent rebar release 2.0.0 and also
the default according to the current documentation in the rebar wiki
(https://github.com/basho/rebar/wiki/Rebar-commands), fixes that issue.
