### PR TITLE
Fix issue with `:joxify` element in require

### DIFF
--- a/src/joxa-compiler.jxa
+++ b/src/joxa-compiler.jxa
@@ -4459,8 +4459,11 @@ errors in a generated function will always be the line number of the macro."
     ((namespace-name . rest)
      (when (erlang/is_atom namespace-name))
      (get-require rest (namespace-name . acc)))
-    (([namespace-name [quote as] _]  . rest)
-     (when  (erlang/is_atom namespace-name))
+    (([namespace-name [:quote :joxify]] . rest)
+     (when (erlang/is_atom namespace-name))
+     (get-require rest (namespace-name . acc)))
+    (([namespace-name [:quote :as] _] . rest)
+     (when (erlang/is_atom namespace-name))
      (get-require rest (namespace-name . acc)))
     (_
      acc)))

--- a/test/jxat_module_info.erl
+++ b/test/jxat_module_info.erl
@@ -14,7 +14,10 @@ given([a,module,that,has,a,require,'and',use], _State, _) ->
                      (phash2 :bar))
 
               (ns jxat-case-test2
-                    (require lists code)
+                    (require
+                        (lists :joxify)
+                        code
+                        (erl_prim_loader :as loader))
                     (use (erlang :only (==/2 phash2/1 and/2))))
 
                 (defn internal-test (arg1 arg2)
@@ -31,5 +34,5 @@ then([context,is,produced], Deps, _) ->
     ?assertMatch(true, erlang:is_list(Deps)),
     {ok, Deps};
 then([context,contains,the,required,information], Deps, _) ->
-      ?assertMatch([{'jxat-case-test2',[erlang,code,lists]},
+      ?assertMatch([{'jxat-case-test2',[erlang,erl_prim_loader,code,lists]},
                     {'jxat-case-test',[erlang,jxat_module_info]}], Deps).


### PR DESCRIPTION
This makes sure that the return value of 'joxa-compiler':info/1,2
always contains a list of _all_ module dependencies.

Prior to that, there was an issue with a module's name being missing
from the list of module dependencies if that particular module was
required with the `:joxify` element.

This adds not only a test case for require clauses with the `:joxify`
element, but also one for those with an `:as` element.
