### PR TITLE
Fix issue with `:as` and `:joxify` in one require

### DIFF
--- a/src/joxa-compiler.jxa
+++ b/src/joxa-compiler.jxa
@@ -4456,13 +4456,10 @@ errors in a generated function will always be the line number of the macro."
   (case form
     ([]
      acc)
+    (((namespace-name . clause-body) . rest)
+     (when (erlang/is_atom namespace-name))
+     (get-require rest (namespace-name . acc)))
     ((namespace-name . rest)
-     (when (erlang/is_atom namespace-name))
-     (get-require rest (namespace-name . acc)))
-    (([namespace-name [:quote :joxify]] . rest)
-     (when (erlang/is_atom namespace-name))
-     (get-require rest (namespace-name . acc)))
-    (([namespace-name [:quote :as] _] . rest)
      (when (erlang/is_atom namespace-name))
      (get-require rest (namespace-name . acc)))
     (_

--- a/test/jxat_module_info.erl
+++ b/test/jxat_module_info.erl
@@ -17,7 +17,8 @@ given([a,module,that,has,a,require,'and',use], _State, _) ->
                     (require
                         (lists :joxify)
                         code
-                        (erl_prim_loader :as loader))
+                        (erl_prim_loader :as loader)
+                        (gen_server :as server :joxify))
                     (use (erlang :only (==/2 phash2/1 and/2))))
 
                 (defn internal-test (arg1 arg2)
@@ -34,5 +35,6 @@ then([context,is,produced], Deps, _) ->
     ?assertMatch(true, erlang:is_list(Deps)),
     {ok, Deps};
 then([context,contains,the,required,information], Deps, _) ->
-      ?assertMatch([{'jxat-case-test2',[erlang,erl_prim_loader,code,lists]},
+      ?assertMatch([{'jxat-case-test2',[erlang,gen_server,erl_prim_loader,
+                                        code,lists]},
                     {'jxat-case-test',[erlang,jxat_module_info]}], Deps).


### PR DESCRIPTION
In the previous commit 224c773c56, we fixed an issue with missing
module dependency information when a require clause contained a
`:joxify` element. In fact, the bugfix was not complete, as it didn't
cover the case with both an `:as` and a `:joxify` element in a require
clause.

Retrieving namespace information for require clauses is now basically
done the same way like for use clauses, i.e., we don't check for the
number, order, or presence of particular elements.
