### PR TITLE
Fix issue with `let/3` macro in records

### DIFF
--- a/src/joxa-records.jxa
+++ b/src/joxa-records.jxa
@@ -181,7 +181,7 @@
         bindings (core/gensym)
         rest (core/gensym))
     `(~def let (~obj ~bindings &rest ~rest)
-           (joxa-records/make-let ~obj ~name '~descs ~bindings ~rest))))
+           (joxa-records/make-let ~obj '~name '~descs ~bindings ~rest))))
 
 (defn create-record (name decl descs)
   (let* (ells (create-elements decl descs)

--- a/test/jxat_records.erl
+++ b/test/jxat_records.erl
@@ -9,7 +9,7 @@ given([a,module,that,has,defined,records], _State, _) ->
           (require joxa-records
                    erlang lists))
 
-(joxa-records/defrecord+ :my-records name age {sex :male} {address \"unknown\"})
+(joxa-records/defrecord+ :test-record name age {sex :male} {address \"unknown\"})
 
 ">>,
 
@@ -31,24 +31,24 @@ given([another,module,uses,those,records], Source1, _) ->
                            {:sex :male}
                            {:address \"Somewhere in Ireland\"}])})
 
-(defn+ match1 (one)
-   (case one
+(defn+ match1 (test-record)
+   (case test-record
      ((jxat-records-def-test/t name \"Robert\")
          :matched)
      (_
          :did-not-match)))
 
 
-(defn+ match2 (one)
-   (case one
+(defn+ match2 (test-record)
+   (case test-record
      ((jxat-records-def-test/t name \"Robert\"
                                sex male)
          :matched)
      (_
          :did-not-match)))
 
-(defn+ match3 (one)
-   (case one
+(defn+ match3 (test-record)
+   (case test-record
      ((jxat-records-def-test/t name \"Robert\"
                                sex :female)
          :matched)
@@ -56,8 +56,8 @@ given([another,module,uses,those,records], Source1, _) ->
          :did-not-match)))
 
 
-(defn+ with (one)
-   (jxat-records-def-test/let one
+(defn+ with (test-record)
+   (jxat-records-def-test/let test-record
                               (name local-name
                                age local-age
                                address local-address)
@@ -100,7 +100,7 @@ then([the,described,function,can,be,called,'and',works,correctly], State, _) ->
                   {t,1}],
                  lists:sort('jxat-records-def-test':module_info(exports))),
     {A, B} = 'jxat-records-uses-test':create1(),
-    ?assertMatch({'my-records',"Robert",1024,male,
+    ?assertMatch({'test-record',"Robert",1024,male,
                   "Somewhere in Ireland"}, A),
     ?assertMatch(A, B),
     ?assertMatch(matched, 'jxat-records-uses-test':match1(A)),
@@ -113,13 +113,13 @@ then([the,described,function,can,be,called,'and',works,correctly], State, _) ->
     ?assertMatch(male, 'jxat-records-def-test':sex(B)),
     ?assertMatch("Somewhere in Ireland",
                  'jxat-records-def-test':address(B)),
-    ?assertMatch({'my-records',"Brian",1024,male,
+    ?assertMatch({'test-record',"Brian",1024,male,
                   "Somewhere in Ireland"}, 'jxat-records-def-test':'name!'(B, "Brian")),
-    ?assertMatch({'my-records',"Robert",3,male,
+    ?assertMatch({'test-record',"Robert",3,male,
                   "Somewhere in Ireland"}, 'jxat-records-def-test':'age!'(B, 3)),
-    ?assertMatch({'my-records',"Robert",1024,never,
+    ?assertMatch({'test-record',"Robert",1024,never,
                   "Somewhere in Ireland"}, 'jxat-records-def-test':'sex!'(B, never)),
-    ?assertMatch({'my-records',"Robert",1024,male,
+    ?assertMatch({'test-record',"Robert",1024,male,
                   "wanderer"},
                  'jxat-records-def-test':'address!'(B, "wanderer")),
   {ok, State}.


### PR DESCRIPTION
This fixes an issue with unwanted variable capture in the `let/3` macro
that's generated by the `defrecord/2` macro. The issue occurred when
the name of the first variable passed to `let/3` (i.e., the record) and
the name of that very record would be the same.

In the corresponding test suite, I've renamed the record that's used
for testing from `my-records` to `test-record`, and renamed any of its
instances being used from `one` to `test-record` as well. Firstly, I
did that in order to have a failing test case for this fix here, but
also in order to cover similar potential issues with other macros that
are being tested there.
