### PR TITLE
Ensure Joxa can be built on (Open|Free)BSD as well

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,9 @@ TLDR
     $> make escript
     $> mv ./_build/joxa/escript/joxa <someplace-in-the-path>
 
+Please note that on *BSD platforms you need to use `gmake` instead of
+`make` in order to build Joxa successfully.
+
 Get The Dependencies
 --------------------
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ ERL=$(shell which erl)
 ERLC=$(shell which erlc)
 REBAR=$(shell which rebar)
 
+CURDIR=$(shell [ -n "$$CURDIR" ] && echo "$$CURDIR" || echo `pwd`)
+
 ifeq ($(REBAR),)
 	$(error "Rebar not available on this system")
 endif
@@ -24,8 +26,8 @@ BUILD_SUPPORT=$(CURDIR)/build-support
 .SUFFIXES:
 .SUFFIXES:.jxa
 
-include $(BUILD_SUPPORT)/core-build.mkf
-include $(BUILD_SUPPORT)/doc.mkf
+include $(abspath $(BUILD_SUPPORT)/core-build.mkf)
+include $(abspath $(BUILD_SUPPORT)/doc.mkf)
 
 clean: jxa-clean doc-clean
 

--- a/build-support/update-versions.sh
+++ b/build-support/update-versions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -8,7 +8,7 @@ JOXA_SHELL=./src/joxa-shell.jxa
 
 version=`$BINDIR/semver.sh`
 
-sed -e "s/\({vsn, \"\).*\(\"\},\)/\1${version}\2/g" ${JOXA_SRC} > ${JOXA_SRC}.tmp
+sed -e "s/\({vsn, \"\).*\(\"},\)/\1${version}\2/g" ${JOXA_SRC} > ${JOXA_SRC}.tmp
 mv ${JOXA_SRC}.tmp ${JOXA_SRC}
 
 sed -e "s/\(Joxa Version \).*\(~n~n\)/\1${version}\2/g" ${JOXA_SHELL} > ${JOXA_SHELL}.tmp

--- a/rebar.config
+++ b/rebar.config
@@ -19,4 +19,4 @@
 
 {escript_emu_args, "%%!\n"}.
 
-{post_hooks, [{compile, "make jxa"}]}.
+{post_hooks, [{compile, "$([ -n \"`which gmake`\" ] && echo \"gmake jxa\" || echo \"make jxa\")"}]}.


### PR DESCRIPTION
Please note that on *BSD platforms you need to use `gmake` instead of
`make` in order to build Joxa successfully.
