### PR TITLE
Fix deadlock issue in concurrent compiler

### DIFF
--- a/src/joxa-cc-wkr.jxa
+++ b/src/joxa-cc-wkr.jxa
@@ -70,14 +70,9 @@ file has not changed then no need to actually build."
           (joxa-concurrent-compiler/build-failure file)
           {:stop :invalid-namespace-definition state})
          (elements
-          (let ({namespaces deps}
-                (joxa-lists/foldl
-                  ({namespace namespace-deps} elements)
-                  ({namespaces deps} {[] []})
-                  {(namespace . namespaces) (lists/append namespace-deps deps)})
-                deps1 (sets/to-list (sets/from-list deps)))
-            (joxa-concurrent-compiler/register-namespaces file namespaces deps1)
-            {:noreply {file opts elements}})))))))
+          (dolist ({namespace deps} elements)
+            (joxa-concurrent-compiler/register-namespace file namespace deps))
+          {:noreply {file opts elements}}))))))
 
 (defn+ terminate (_reason state)
   :ok)

--- a/src/joxa-concurrent-compiler.jxa
+++ b/src/joxa-concurrent-compiler.jxa
@@ -54,9 +54,9 @@ to notify the coordinator."
 notify the coordinator."
   (gen-server/cast ($namespace) {:failure file}))
 
-(defn+ register-namespaces (file namespaces deps)
+(defn+ register-namespace (file namespace deps)
   "Register a namespace with its dependencies."
-  (gen-server/cast ($namespace) {:register file namespaces deps}))
+  (gen-server/cast ($namespace) {:register file namespace deps}))
 
 (defspec joxa-cc-wkr/start-link ((string) (list))  (pid))
 (defspec joxa-cc-wkr/build (pid) :ok)
@@ -136,16 +136,15 @@ frees for building anything that is currently able to be built."
          :ok)))
     (state/dep-info! state0 dep-info1)))
 
-(defn register (state0 file namespaces deps)
+(defn register (state0 file namespace deps)
   "When a worker gets done gathering information about the
 file/namespace it registers that information with the concurrent
 compiler. This does the register and when all files are registered it
 starts building."
-  (let* (state1 (joxa-lists/foldl (namespace namespaces) (state state0)
-                  (check-existence! state file namespace)
-                  (let* (state (check-cycles! state namespace deps))
-                    (state/dep-info! state ({file namespace deps :unbuilt} .
-                                            (state/dep-info state)))))
+  (let* (state1 (do (check-existence! state0 file namespace)
+                    (let* (state (check-cycles! state0 namespace deps))
+                      (state/dep-info! state ({file namespace deps :unbuilt} .
+                                              (state/dep-info state)))))
          new-starting (lists/delete file (state/starting state1)))
     (case new-starting
       ([]
@@ -156,8 +155,8 @@ starts building."
 ;;; gen-server callbacks
 (defn+ handle-cast (request state)
   (case request
-    ({:register file namespaces deps}
-     {:noreply (register state file namespaces deps)})
+    ({:register file namespace deps}
+     {:noreply (register state file namespace deps)})
     ({:success file}
      {:noreply (done-building state file :built)})
     ({:skip file}

--- a/test/jxat_concurrent_compiler.erl
+++ b/test/jxat_concurrent_compiler.erl
@@ -24,6 +24,17 @@ given([a,bunch,'of',joxa,source,files], _State, _) ->
                (defrecord+ a b c d)">>
        },
        {
+           "jxat-cc-abc.jxa",
+           <<"(ns jxat-cc-a
+                (use joxa-records))
+              (defrecord+ a b c)
+              (ns jxat-cc-b
+                (require jxat-cc-a))
+              (defn+ foo () (jxat-cc-a/make 1 2 3))
+              (ns jxat-cc-c)
+              (defn+ bar () 42)">>
+       },
+       {
            "jxat-cc-foo.jxa",
            <<"(ns jxat-cc-foo
                 (require jxat-cc-foo-record-1 (erlang :as erl)))
@@ -74,6 +85,9 @@ then([all,files,are,compiled,successfully], Result, _) ->
         ".eunit/jxat-cc-foo-record-3.beam",
         ".eunit/jxat-cc-foo-record-4.beam",
         ".eunit/jxat-cc-foo-record-5.beam",
+        ".eunit/jxat-cc-a.beam",
+        ".eunit/jxat-cc-b.beam",
+        ".eunit/jxat-cc-c.beam",
         ".eunit/jxat-cc-foo.beam",
         ".eunit/jxat-cc-bar.beam",
         ".eunit/jxat-cc-baz.beam",


### PR DESCRIPTION
This fixes an issue where the concurrent compiler would get into a
deadlock when there would be more than two namespace declarations in
one source file and at least one interdependency between those
namespaces.

The problem was that the concurrent compiler only got a list of all
namespace dependencies on a per file level, but not on a per namespace
level. Hence, it was possible that for some namespace `sample-ns` the
list of namespace dependencies would also contain that very namespace
itself, e.g., it would be `['sample-ns']`. As a consequence, it would
wait indefinitely for the compilation that it was itself responsible
for.
