### PR TITLE
Replace `sed` with `perl` in build-support scripts

### DIFF
--- a/build-support/semver.sh
+++ b/build-support/semver.sh
@@ -22,15 +22,15 @@ vsn=
 get_version_candidate()
 {
     version_regex='tag: (v([^,\)]+)|([0-9]+(\.[0-9]+)*))'
-    tag_lines=`git log --oneline --decorate | fgrep "tag: "`
-    version_match=`echo "$tag_lines" | sed -r -e "s/^.*\($version_regex\).*/\1/;q"`
+    tag_lines=$(git log --oneline --decorate | fgrep "tag: ")
+    version_match=$(echo "$tag_lines" | perl -e "<> =~ /\($version_regex\)/ && print \${1}")
 
     if [ -n "$version_match" ]; then
-        if [ `echo "$version_match" | sed -r -e 's/^(.).*/\1/'` = "v" ]; then
+        if [ $(echo "$version_match" | perl -e '<> =~ /(.)/ && print ${1}') = 'v' ]; then
             version_tag="$version_match"
-            version_candidate=`echo "$tag_lines" | sed -r -e "s/^.*\($version_regex\).*/\2/;q"`
+            version_candidate=$(echo "$tag_lines" | perl -e "<> =~ /\($version_regex\)/ && print \${2}")
         else
-            version_tag=`echo "$tag_lines" | sed -r -e "s/.*\($version_regex\).*/\3/;q"`
+            version_tag=$(echo "$tag_lines" | perl -e "<> =~ /\($version_regex\)/ && print \${3}")
             version_candidate="$version_tag"
         fi
     else
@@ -42,11 +42,11 @@ get_version_candidate()
 get_commit_count()
 {
     if [ $version_tag = "" ]; then
-        commit_count=`git rev-list HEAD | wc -l`
+        commit_count=$(git rev-list HEAD | wc -l)
     else
-        commit_count=`git rev-list ${version_tag}..HEAD | wc -l`
+        commit_count=$(git rev-list ${version_tag}..HEAD | wc -l)
     fi
-    commit_count=`echo $commit_count | tr -d ' 't`
+    commit_count=$(echo $commit_count | tr -d ' 't)
 }
 
 build_version()
@@ -54,7 +54,7 @@ build_version()
     if [ $commit_count = 0 ]; then
         vsn=$version_candidate
     else
-        local ref=`git log -n 1 --pretty=format:'%h'`
+        local ref=$(git log -n 1 --pretty=format:'%h')
         vsn="${version_candidate}+build.${commit_count}.${ref}"
     fi
 }

--- a/build-support/update-versions.sh
+++ b/build-support/update-versions.sh
@@ -6,10 +6,10 @@ BINDIR=$( cd "$( dirname "$0" )" && pwd )
 JOXA_SRC=./src/joxa.app.src
 JOXA_SHELL=./src/joxa-shell.jxa
 
-version=`$BINDIR/semver.sh`
+version=$($BINDIR/semver.sh)
 
-sed -e "s/\({vsn, \"\).*\(\"},\)/\1${version}\2/g" ${JOXA_SRC} > ${JOXA_SRC}.tmp
+cat ${JOXA_SRC} | perl -p -e "s/({vsn, \")[^\"]*(\"},)/\${1}${version}\${2}/g" > ${JOXA_SRC}.tmp
 mv ${JOXA_SRC}.tmp ${JOXA_SRC}
 
-sed -e "s/\(Joxa Version \).*\(~n~n\)/\1${version}\2/g" ${JOXA_SHELL} > ${JOXA_SHELL}.tmp
+cat ${JOXA_SHELL} | perl -p -e "s/(Joxa Version ).*?(~n~n)/\${1}${version}\${2}/g" > ${JOXA_SHELL}.tmp
 mv ${JOXA_SHELL}.tmp ${JOXA_SHELL}


### PR DESCRIPTION
This replaces `sed` with `perl`, as `sed` caused nasty issues with
implementations on different platforms behaving different.

When implementing these changes invoking a subshell using the
backticks-syntax didn't always work. In order to be sure, and also for
consistency reasons, all invocations of a subshell are now done using
the syntax with dollar sign parentheses.

Fixes #45.
