### PR TITLE
Generate `start-link/0` in `joxa-otp-supervisor`

### DIFF
--- a/src/joxa-otp-supervisor.jxa
+++ b/src/joxa-otp-supervisor.jxa
@@ -10,8 +10,11 @@
 (defmacro+ gen-start-link ()
   ;; Create a default start link function for the most common
   ;; supervisor start method
-  `(defn+ start_link ()
-     (supervisor/start_link {:local ($namespace)} ($namespace) [])))
+  `(do
+     (defn+ start_link ()
+       (supervisor/start_link {:local ($namespace)} ($namespace) []))
+     (defn+ start-link ()
+       (start_link))))
 
 (defn+ default-init (child-list)
   ;; Create a default supervisor spec based on a list of child


### PR DESCRIPTION
This changes the `gen-start-link` macro in `joxa-otp-supervisor` so that
it also generates a function `start-link/0` which does nothing more than
call `start_link/0`.
