### PR TITLE
Remove `require_otp_vsn` from rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,4 @@
 %% -*- mode: erlang; -*-
-{require_otp_vsn, "R15B.*"}.
 {deps,
  [{cucumberl, ".*",
    {git, "http://github.com/ericbmerritt/cucumberl.git",


### PR DESCRIPTION
Closes #51.
