### PR TITLE
support building escriptized joxa on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.beam
 ebin/joxa.app
 joxa
+joxa.cmd
 deps
 _build
 erl_crash.dump

--- a/build-support/core-build.mkf
+++ b/build-support/core-build.mkf
@@ -121,6 +121,7 @@ cucumber: eunit $(SRCBEAMS) $(TESTBEAMS)
 
 bare-escript:
 	$(REBAR) skip_deps=true escriptize
+	$(REBAR) -C rebar.windows.config skip_deps=true escriptize
 
 escript: build bare-escript
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -11,6 +11,8 @@ Machine. So either install that
 `now from source <http://www.erlang.org>`_ or install it from the
 packaging system on your distribution.
 
+If you are using Windows, install a recent Erlang (R15B or newer), add
+Erlang's bin directory to your path, and drop ``joxa.cmd`` in there too.
 
 How to properly install your project. Ideally, your project should be
 installable via a common (simplistic) method: PyPI for Python, PEAR

--- a/rebar.windows.config
+++ b/rebar.windows.config
@@ -1,0 +1,26 @@
+%% -*- mode: erlang; -*-
+{require_otp_vsn, "R15B.*"}.
+{deps,
+ [{cucumberl, ".*",
+   {git, "http://github.com/ericbmerritt/cucumberl.git",
+    {tag, "v0.0.5"}}},
+  {getopt, ".*",
+   {git, "https://github.com/jcomellas/getopt.git",
+    {tag, "v0.4.4"}}},
+  {proper, ".*",
+   {git, "https://github.com/manopapad/proper.git",
+    {tag, "v1.0"}}},
+  {erlware_commons, ".*",
+   {git, "https://github.com/erlware/erlware_commons.git",
+    {tag, "v0.7.0"}}}]}.
+
+{escript_incl_apps,
+ [erlware_commons, getopt]}.
+
+
+{escript_name, "joxa.cmd"}.
+{escript_shebang, "@echo off & setlocal & path=%~dp0;%path%; & escript.exe \"%~dpn0.cmd\" %* & endlocal & goto :eof\n"}.
+{escript_comment, "%% -*- erlang -*-\n"}.
+{escript_emu_args, "%%! -smp enable\n"}.
+
+{post_hooks, [{compile, "make jxa"}]}.


### PR DESCRIPTION
This isn't ready to commit yet, but might be close enough for somebody else to finish off.  I've asked if there's a way to tell rebar to:
- support multiple output targets (generate both joxa and joxa.cmd)
- use platform-specific escript_\* targets

Else this would need to be done in post_hooks somehow.

This rebar tweak produces a valid escript `joxa` archive for windows, that can simply be renamed to `joxa.cmd` and is ready to run. This can be built on unix, it doesn't need a windows development environment.

```
diff --git i/rebar.config w/rebar.config
index 8c546c7..28de4e7 100644
--- i/rebar.config
+++ w/rebar.config
@@ -17,6 +17,9 @@
 {escript_incl_apps,
  [erlware_commons, getopt]}.

-{escript_emu_args, "%%!\n"}.
+
+{escript_shebang, "@echo off & setlocal & path=%~dp0;%path%; & escript.exe \"%~dpn0.cmd\" %* & endlocal & goto :eof\n"}.
+{escript_comment, "%% -*- erlang -*-\n"}.
+{escript_emu_args, "%%! -smp enable\n"}.

 {post_hooks, [{compile, "make jxa"}]}.
```
