### PR TITLE
Fix dependency cycle detection

### DIFF
--- a/build-support/core-build.mkf
+++ b/build-support/core-build.mkf
@@ -59,7 +59,8 @@ TESTBEAMS = $(TEST_EBIN)/joxa-test-let-match.beam \
 	$(TEST_EBIN)/joxa-test-core-and.beam \
 	$(TEST_EBIN)/joxa-test-core-or.beam \
 	$(TEST_EBIN)/joxa-test-core-add.beam \
-	$(TEST_EBIN)/joxa-test-core-subtract.beam
+	$(TEST_EBIN)/joxa-test-core-subtract.beam \
+	$(TEST_EBIN)/joxa-test-cc.beam
 
 .PHONY: all bootstrap clean update-versions \
 	jxa test build get-deps proper eunit \

--- a/src/joxa-concurrent-compiler.jxa
+++ b/src/joxa-concurrent-compiler.jxa
@@ -9,7 +9,6 @@
     (use (joxa-records :only (defrecord+/1))))
 
 (defrecord+
-  {dep-graph []} ; topo sorted dep graph for cycle detection
   {all-pids []}
   {starting []}
   {dep-info []})
@@ -62,16 +61,17 @@ notify the coordinator."
 (defspec joxa-cc-wkr/start-link ((string) (list))  (pid))
 (defspec joxa-cc-wkr/build (pid) :ok)
 
-(defn check-cycles! (state namespace deps)
-  "Make sure that there are no cycles in the dependency graph. If there
-are exit the build."
-  (let* (dep-sub-graph
-         (map (dep deps)
-              {namespace deps}))
-    (case (joxa-sort-topo/sort (lists/append
-                                (state/dep-graph state)))
-      ({:ok new-dep-graph}
-       (state/dep-graph! state new-dep-graph))
+(defn check-cycles! (namespace-deps)
+  "Make sure that there are no cycles in the dependency graph. This
+exits the build if a cycle is found."
+  (let* (namespace-dep-pairs (foldl ({namespace deps} namespace-deps) (acc [])
+                               (lists/append
+                                 (foldl (dep deps) (acc1 [])
+                                   ({namespace dep} . acc1))
+                                 acc)))
+    (case (joxa-sort-topo/sort namespace-dep-pairs)
+      ({:ok _}
+       :ok)
       ({:cycle cycle}
        (io/format :standard_error "Dependency cycle detected ~p~n" [cycle])
        (erlang/exit {:cycle-detected cycle})))))
@@ -144,12 +144,15 @@ compiler. This does the register and when all files are registered it
 starts building."
   (let* (state1 (foldl ({namespace deps} namespace-deps-list) (state1 state0)
                   (check-existence! state1 file namespace)
-                  (let* (state (check-cycles! state1 namespace deps))
-                    (state/dep-info! state ({file namespace deps :unbuilt} .
-                                            (state/dep-info state)))))
+                  (state/dep-info! state1 ({file namespace deps :unbuilt} .
+                                           (state/dep-info state1))))
          new-starting (lists/delete file (state/starting state1)))
     (case new-starting
       ([]
+       (let* (namespace-deps-pairs
+              (map ({_ namespace deps _} (state/dep-info state1))
+                {namespace deps}))
+         (check-cycles! namespace-deps-pairs))
        (start-building (state/starting! state1 new-starting)))
       (_
        (state/starting! state1 new-starting)))))

--- a/test/joxa-test-cc.jxa
+++ b/test/joxa-test-cc.jxa
@@ -1,0 +1,56 @@
+(ns joxa-test-cc
+  (use joxa-assert
+       joxa-core
+       joxa-lists)
+  (require joxa-eunit
+           joxa-concurrent-compiler
+           (filename :joxify)
+           (file :joxify)
+           (code :joxify)))
+
+(define file-a
+  <<"(ns joxa-test-cc-a
+       (require joxa-test-cc-b))
+     (defn+ hello ()
+       (joxa-test-cc-b/world))
+     (defn+ world ()
+       42)">>)
+
+(define file-b
+  <<"(ns joxa-test-cc-b
+       (require joxa-test-cc-a))
+     (defn+ hello ()
+       (joxa-test-cc-a/world))
+     (defn+ world ()
+       43)">>)
+
+(define file-c
+  <<"(ns joxa-test-cc-c)
+     (defn+ hello ()
+       :hello)">>)
+
+(define file-d
+  <<"(ns joxa-test-cc-d)
+     (defn+ world ()
+       :world)">>)
+
+(defn compile-files (filename-file-pairs)
+  (let* (filepaths
+         (map ({filename file} filename-file-pairs)
+           (let* (pwd (filename/dirname (code/which ($namespace)))
+                  file-path (filename/join [pwd filename]))
+             (file/write-file file-path file)
+             file-path)))
+    (joxa-concurrent-compiler/do-compile filepaths [])))
+
+(defn+ return-success_test ()
+  (assert-equal
+    :ok
+    (compile-files [{"joxa-test-cc-c.jxa" (file-c)}, {"joxa-test-cc-d.jxa" (file-d)}])))
+
+(defn+ cycles_test ()
+  (assert-match
+    {:error {:cycle-detected _}}
+    (compile-files [{"joxa-test-cc-a.jxa" (file-a)} {"joxa-test-cc-b.jxa" (file-b)}])))
+
+(joxa-eunit/testable)


### PR DESCRIPTION
This fixes dependency cycle detection in the concurrent compiler and
includes a test case therefor.
