### PR TITLE
fixed clause generation in receive

### DIFF
--- a/src/joxa-cmp-case.jxa
+++ b/src/joxa-cmp-case.jxa
@@ -384,3 +384,16 @@
     ((clause . rest)
      (let* (clauses (make-pattern-clause-body (joxa-cmp-path/traverse-path path0) ctx clause))
        (make-pattern (joxa-cmp-path/incr-path path0) ctx rest (clauses . acc))))))
+
+(defn+ make-pattern-receive (path0 ctx form acc)
+  (case form
+    ([]
+     (joxa-cmp-ctx/add-error-r-nil-ctx ctx path0 :no-clauses-provided))
+    ([clause]
+     (let* (clauses (make-pattern-clause-body (joxa-cmp-path/traverse-path path0) ctx clause))
+       (lists/reverse (clauses . acc))))
+    ((clause . rest)
+     (let* (clauses (make-pattern-clause-body (joxa-cmp-path/traverse-path path0) ctx clause))
+       (make-pattern-receive (joxa-cmp-path/incr-path path0) ctx rest (clauses . acc))))))
+
+

--- a/src/joxa-cmp-expr.jxa
+++ b/src/joxa-cmp-expr.jxa
@@ -371,7 +371,7 @@
                                     ctx timeout)
              timeout-expr  (make-seq (joxa-cmp-path/incr-path 2 (joxa-cmp-path/traverse-incr-path path0))
                                      ctx do-exprs)
-             cerl-clauses (joxa-cmp-case/make-pattern (joxa-cmp-path/incr-path 2 path0) ctx clauses []))
+             cerl-clauses (joxa-cmp-case/make-pattern-receive (joxa-cmp-path/incr-path 2 path0) ctx clauses []))
          (case (cerl/is_c_int timeout-val)
            (:true
             (cerl/ann_c_receive annots
@@ -383,7 +383,7 @@
       ((:receive . ((:after . _) . _))
        (joxa-cmp-ctx/add-error-r-nil-ctx ctx path0 :invalid-receive))
       ((:receive . clauses)
-       (let* (cerl-clauses (joxa-cmp-case/make-pattern (joxa-cmp-path/incr-path path0) ctx clauses []))
+       (let* (cerl-clauses (joxa-cmp-case/make-pattern-receive (joxa-cmp-path/incr-path path0) ctx clauses []))
          (cerl/ann_c_receive annots cerl-clauses)))
       ((:do . args)
        (make-seq (joxa-cmp-path/incr-path path0) ctx args))


### PR DESCRIPTION
I have identified the issue and propose a fix.  I checked that this correctly generates clauses for receives by compiling to core erlang.  You may want to handle this differently but this pull request should help you identify quickly where the problem is - it was indeed code reuse as you suggested.
