### PR TITLE
Add doc for let(*) and fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ More information can be found on the
 [Joxa Manual](http://docs.joxa.org). Install instructions are in
 INSTALL.md colocated with this Readme. Of course, the canonical source
 for all docs and code is the
-[github repo](http://github.com/erlware/joxa)
+[github repo](http://github.com/joxa/joxa)

--- a/build-support/build.erl
+++ b/build-support/build.erl
@@ -37,7 +37,7 @@ main(["bootstrap", ASTDir, OutDir]) ->
         end,
     lists:foreach(F, modules());
 main(["compile", SrcDir, OutDir]) ->
-    %% compiling the rest of joxa (after botstrapping)
+    %% compiling the rest of joxa (after bootstrapping)
     update_code_path(),
     io:format("~n--- compiling ---~n"),
     F = fun(E) ->

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -98,7 +98,7 @@ We define a function called `sieve` that takes two arguments. The
 argument `v` and, next, the argument `primes`. We then have a
 single `case` expression that forms the body of the function. A case
 expression allows the author to do pattern matching on the second
-clause of the expression. While he rest of the clauses identify
+clause of the expression. While the rest of the clauses identify
 patterns and what will be evaluate based on the form of the output of
 the second clause. In this example, you can see that an empty list
 will return the argument `primes` unchanged while a cons cell will

--- a/doc/language.rst
+++ b/doc/language.rst
@@ -631,7 +631,7 @@ Author's Note
 
 When you use `require` vs `use` is entirely up to you. Joxa is a young
 language and there has not yet been time to hash out what is the best
-practice here. I have had the good fortune to code in may languages
+practice here. I have had the good fortune to code in many languages
 and several of those languages have supported 'import' clause's like
 use. In the best of those languages the general practice is to use the
 `use` clause only when you are importing *operators* the require

--- a/doc/language.rst
+++ b/doc/language.rst
@@ -38,7 +38,6 @@ version of `let*` in Joxa. It's similar to the `let` in Clojure, which
 could be used for destructuring, e.g.,
 
 .. code-block:: clojure
-
                 
   (let (a 1
         {b _} {a 2})

--- a/doc/language.rst
+++ b/doc/language.rst
@@ -43,7 +43,7 @@ could be used for destructuring, e.g.,
         {b _} {a 2})
     b)
 
-`let` wouldn't work in this case, because the expression `{b _}` doesn't
+`let*` wouldn't work in this case, because the expression `{b _}` doesn't
 evaluate to any valid value. The underscore could be used in the place of a
 named variable to ignore the corresponding binding, which is the same as
 pattern matching in Erlang or desctructuring in Clojure. Currently

--- a/doc/language.rst
+++ b/doc/language.rst
@@ -11,6 +11,45 @@ let*
 
   (let* (val val-expr ...) expr ...)
 
+A non-pattern matching function to bind variables locally. It's similar to `let*`
+in Common Lisp, so it could bind the later variable from the previous one, e.g.,
+
+.. code-block:: clojure
+
+  (let* (a 1
+         b a)
+    b)
+
+In this case, it's not like `let` in Common Lisp.
+It's designed as primitive to use in macros and the like. In fact,
+the macro `let` is defined by `let*` in `joxa-core`, which is a good example
+for the usage of `let*`.
+
+
+let
+^^^^
+
+.. code-block:: clojure
+
+  (let (val val-expr ...) expr ...)
+
+A pattern matching macro to bind variable locally. It's a pattern matching
+version of `let*` in Joxa. It's similar to the `let` in Clojure, which
+could be used for destructuring, e.g.,
+
+.. code-block:: clojure
+
+                
+  (let (a 1
+        {b _} {a 2})
+    b)
+
+`let` wouldn't work in this case, because the expression `{b _}` doesn't
+evaluate to any valid value. The underscore could be used in the place of a
+named variable to ignore the corresponding binding, which is the same as
+pattern matching in Erlang or desctructuring in Clojure. Currently
+there is no warning or error on unused binding.
+
 try*
 ^^^^
 

--- a/doc/standard-library.rst
+++ b/doc/standard-library.rst
@@ -643,12 +643,11 @@ in the tuple and its default value. In our example-person record the
 result of `field-info/0` is
 
 .. code-block:: clojure
-
-  [{name,2,undefined},
-   {age,3,undefined},
-   {sex,4,male},
-   {address,5,"Somewhere in Ireland"},
-   {city,6,undefined}]
+  [{name,2,[quote,undefined]},
+   {age,3,[quote,undefined]},
+   {sex,4,[quote,male]},
+   {address,5,"unknown"},
+   {city,6,[quote,undefined]}]
 
 As you can see it gives you metadata for all the
 fields. `field-info/1` returns the same metadata but only for a single
@@ -656,7 +655,7 @@ field. So if we called `field-info` with `name` we would get
 
 .. code-block:: clojure
 
-    {name,2,undefined}
+    {name,2,[quote,undefined]}
 
 Future Directions
 -----------------


### PR DESCRIPTION
Hi there,

I add some docs for let(*) according to this email topic
[let, let* and multiple local variable bindings](https://groups.google.com/forum/#!topic/joxa/UPrrI8ctMWE)
and fix some typos.

I try to collect these infos into this repo. But I am not sure about the style of these new docs which mention other languages such as clojure, common lisp so much. Hope that would not lead to confusion because of the analogy between let(*) in Joxa and other languages. Please revise those paragraphs to be preciser/better if necessary.

BTW, the documentation in
[http://joxa.readthedocs.org/en/latest/index.html](http://joxa.readthedocs.org/en/latest/index.html)
is not as up to date  as the doc in this repo. I notice [the section about creating records](
http://joxa.readthedocs.org/en/latest/standard-library.html#creating-records) is obsolete and it caused some problem when I tried to run that code.
