### PR TITLE
Fix compilation breaks for Erlang/OTP 21

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {deps,
  [{cucumberl, ".*",
    {git, "http://github.com/ericbmerritt/cucumberl.git",
-    {tag, "v0.0.5"}}},
+    "623faa48"}},
   {getopt, ".*",
    {git, "https://github.com/jcomellas/getopt.git",
     {tag, "v0.4.4"}}},


### PR DESCRIPTION
The BIF `erlang:get_stacktrace/0` is deprecated in Erlang/OTP 21. Because the dependency `cucumber` used this BIF, it causes failure on compilation. This PR upgrades `cucumber` to its latest version, with this BIF removed, to fix compilation failure for `joxa` on Erlang/OTP 21.

Refer to:

issue joxa/joxa#13
PR ericbmerritt/cucumberl#3

